### PR TITLE
updated php_codesniffer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "squizlabs/php_codesniffer": "~1.5",
+        "squizlabs/php_codesniffer": "~1.5|~2.3",
         "beberlei/assert": "2.*"
     },
     "require-dev": {


### PR DESCRIPTION
squizlabs/php_codesniffer is now updated

It works with the older and new version without any modification.
![phpunit](http://i.imgur.com/J8DJHrH.png)
